### PR TITLE
修复阳历转农历日期多一天的bug

### DIFF
--- a/lib/chinese-lunar.js
+++ b/lib/chinese-lunar.js
@@ -537,7 +537,7 @@
 
 		//农历初一对应公历的哪一天
 		var firstDay = new Date(data.year, data.month - 1, data.day);
-		var day = _solarDiff(solar, firstDay, "d") + 1;
+		var day = _solarDiff(solar, firstDay, "d");
 
 		//返回的农历结果
 		var result = {


### PR DESCRIPTION
比如： "2019-08-21T06:31:48.400Z" 即 东八区 8月21日 
转后为 2019年七月二十二，  实际应该为 七月二十一
_solarDiff中转化d的时候 用的是Math.ceil 已经是向上取整了，这里无需再加1